### PR TITLE
Lecture 17 homework

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,6 +2,10 @@ import pytest
 from enum import Enum
 import requests
 from time import sleep
+import logging
+
+log = logging.getLogger(__name__)
+
 
 class SensorMethod(Enum):
     GET_INFO = "get_info"
@@ -57,7 +61,7 @@ def sensor_pin(request):
 
 @pytest.fixture(scope="session")
 def send_post(sensor_host, sensor_port, sensor_pin):
-    def inner(
+    def _send_post(
         method: SensorMethod | None = None,
         params: dict | None = None,
         jsonrpc: str | None = None,
@@ -86,98 +90,139 @@ def send_post(sensor_host, sensor_port, sensor_pin):
 
         return res.json()
 
-    return inner
+    return _send_post
 
 
 @pytest.fixture(scope="session")
 def make_valid_request(send_post):
-    def inner(method: SensorMethod, params: dict | None = None) -> dict:
+    def _make_valid_request(method: SensorMethod, params: dict | None = None) -> dict:
         payload = make_valid_payload(method=method, params=params)
         sensor_response = send_post(**payload)
         return sensor_response.get("result", {})
 
-    return inner
+    return _make_valid_request
 
 
 @pytest.fixture(scope="session")
 def get_sensor_info(make_valid_request):
-    def inner():
+    def _get_sensor_info():
+        log.info("Get sensor info")
         return make_valid_request(SensorMethod.GET_INFO)
 
-    return inner
-
-
-@pytest.fixture
-def get_sensor_reading(make_valid_request):
-    def inner():
-        return make_valid_request(SensorMethod.GET_READING)
-
-    return inner
-
-
-@pytest.fixture
-def set_sensor_name(make_valid_request):
-    def inner(name: str):
-        return make_valid_request(SensorMethod.SET_NAME, {"name": name})
-
-    return inner
-
-
-@pytest.fixture
-def get_sensor_methods(make_valid_request):
-    def inner():
-        return make_valid_request(SensorMethod.GET_METHODS)
-
-    return inner
-
-
-@pytest.fixture
-def set_sensor_reading_interval(make_valid_request):
-    def inner(reading_interval: int):
-        return make_valid_request(SensorMethod.SET_READING_INTERVAL, {"interval": reading_interval})
-
-    return inner
+    return _get_sensor_info
 
 
 @pytest.fixture(scope="session")
-def reset_sensor_to_factory(make_valid_request):
-    def inner():
-        return make_valid_request(SensorMethod.RESET_TO_FACTORY)
+def get_sensor_reading(make_valid_request):
+    def _get_sensor_reading():
+        log.info("Get sensor reading")
+        return make_valid_request(SensorMethod.GET_READING)
 
-    return inner
+    return _get_sensor_reading
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
+def set_sensor_name(make_valid_request):
+    def _set_sensor_name(name: str):
+        log.info("Set sensor name to %s", name)
+        return make_valid_request(SensorMethod.SET_NAME, {"name": name})
+
+    return _set_sensor_name
+
+
+@pytest.fixture(scope="session")
+def get_sensor_methods(make_valid_request):
+    def _get_sensor_methods():
+        log.info("Get sensor methods")
+        return make_valid_request(SensorMethod.GET_METHODS)
+
+    return _get_sensor_methods
+
+
+@pytest.fixture(scope="session")
+def set_sensor_reading_interval(make_valid_request):
+    def _set_sensor_reading_interval(reading_interval: int):
+        log.info("Set sensor reading interval to %d seconds", reading_interval)
+        return make_valid_request(SensorMethod.SET_READING_INTERVAL, {"interval": reading_interval})
+
+    return _set_sensor_reading_interval
+
+
+@pytest.fixture(scope="session")
+def reset_sensor_to_factory(make_valid_request, get_sensor_info):
+    def _reset_sensor_to_factory():
+        log.info("Send reset firmware request to sensor")
+        sensor_response = make_valid_request(SensorMethod.RESET_TO_FACTORY)
+        if sensor_response != "resetting":
+            raise RuntimeError(
+                "Sensor didn't respond to factory reset properly"
+            )
+
+        sensor_info = wait(
+            get_sensor_info, lambda x: isinstance(x, dict), tries=15, timeout=1
+        )
+        if not sensor_info:
+            raise RuntimeError("Sensor didn't reset to factory property")
+
+        return sensor_info
+    return _reset_sensor_to_factory
+
+
+@pytest.fixture(scope="session")
 def update_sensor_firmware(make_valid_request):
-    def inner():
+    def _update_sensor_firmware():
+        log.info("Send firmware update request to sensor")
         return make_valid_request(SensorMethod.UPDATE_FIRMWARE)
 
-    return inner
+    return _update_sensor_firmware
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def reboot_sensor(make_valid_request):
-    def inner():
+    def _reboot_sensor():
+        log.info("Send reboot request to sensor")
         return make_valid_request(SensorMethod.REBOOT)
 
-    return inner
+    return _reboot_sensor
 
-
-@pytest.fixture(autouse=True, scope="session")
-def setup_test_session(reset_sensor_to_factory, get_sensor_info):
-    print("Resetting sensor to factory settings before test session")
-    reset_sensor_to_factory()
-    sensor_info = wait(get_sensor_info, lambda x: isinstance(x, dict), tries=15, timeout=1)
-    if not sensor_info:
-        raise RuntimeError("Sensor didn't reset to factory property")
-    
 
 def wait(func: callable, condition: callable, tries: int, timeout: int, **kwargs):
-    for _ in range(tries):
+    for i in range(tries):
         try: 
+            log.debug(
+                f"Calling function {func.__name__} with args {kwargs} - attempt {i + 1}"
+            )
             result = func(**kwargs)
 
+            log.debug(
+                f"Evaluating result of the call with function {condition.__name__}"
+            )
             if condition(result):
                 return result
         except Exception as e:
-            sleep(timeout)    
+            log.debug(f"Function call raised exception {e}, ignoring it")
+
+        log.debug(f"Sleeping for {timeout} seconds")
+        sleep(timeout)  
+          
+    log.debug(
+        "Exhausted all tries, condition evaluates to False, returning None"
+    )
+    return
+
+
+@pytest.fixture(scope="session")
+def factory_sensor_settings(reset_sensor_to_factory):
+    log.info("Reset sensor to factory defaults")
+    yield reset_sensor_to_factory()
+
+
+@pytest.fixture(autouse=True)
+def ensure_sensor_factory_settings(
+    factory_sensor_settings, reset_sensor_to_factory, get_sensor_info
+):
+    current_sensor_settings = get_sensor_info()
+    log.info("Ensure sensor has factory settings before starting test")
+    if current_sensor_settings != factory_sensor_settings:
+        log.info("Detected non-factory settings, resetting sensor")
+        reset_sensor_to_factory()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+log_cli_format = %(asctime)s %(levelname)-8s %(funcName)-40s %(filename)-20s %(lineno)-3d %(message)s

--- a/sensor_test.py
+++ b/sensor_test.py
@@ -1,5 +1,8 @@
-from time import sleep
+import logging
 from conftest import wait
+
+
+log = logging.getLogger(__name__)
 
 
 def test_sanity(
@@ -47,14 +50,14 @@ def test_reboot(get_sensor_info, reboot_sensor):
     5. Validate that info from Step 1 is equal to info from Step 4
     """
 
-    print("Get sensor info before reboot")
+    log.info("Get sensor info before reboot")
     sensor_info_before_reboot = get_sensor_info()
-    print("Reboot sensor")
+
+    log.info("Reboot sensor")
     reboot_response = reboot_sensor()
     assert reboot_response == "rebooting", "Sensor did not reboot"
 
-    print("Wait for sensor to come back online and get sensor info after reboot")
-
+    log.info("Wait for sensor to come back online and get sensor info after reboot")
     sensor_info_after_reboot = wait(
         func=get_sensor_info,
         condition=lambda x: isinstance(x, dict),
@@ -62,7 +65,7 @@ def test_reboot(get_sensor_info, reboot_sensor):
         timeout=1,
     )
 
-    print("Validate that info from Step 1 is equal to info from Step 4")
+    log.info("Validate that info from Step 1 is equal to info from Step 4")
     assert (
         sensor_info_before_reboot == sensor_info_after_reboot
     ), "Sensor info after reboot does not match sensor info before reboot"
@@ -75,16 +78,15 @@ def test_set_sensor_name(get_sensor_info, set_sensor_name):
     3. Validate that current sensor name matches the name set in Step 1.
     """
     new_sensor_name = "new_name"
-
-    print('Set sensor name to "new_name"')
+    log.info('Set sensor name to "new_name"')
     set_sensor_name(new_sensor_name)
 
-    print("Get sensor_info")
+    log.info("Get sensor_info")
     sensor_info = get_sensor_info()
 
     current_sensor_name = sensor_info.get("name")
 
-    print("Validate that current sensor name matches the name set in Step 1")
+    log.info("Validate that current sensor name matches the name set in Step 1")
     assert (
         new_sensor_name == current_sensor_name
     ), "Current sensor name does not match the name set in step 1"
@@ -104,18 +106,18 @@ def test_set_sensor_reading_interval(
     """
     reading_interval = 1
 
-    print("Set sensor reading interval to 1")
+    log.info("Set sensor reading interval to 1")
     set_sensor_reading_interval(reading_interval)
 
-    print("Validate that sensor reading interval is set to interval from Step 1")
+    log.info("Validate that sensor reading interval is set to interval from Step 1")
     assert (
         get_sensor_info().get("reading_interval") == reading_interval
     ), "Sensor reading interval is not set to interval from Step 1"
 
-    print("Get sensor reading")
+    log.info("Get sensor reading")
     sensor_reading_before_wait = get_sensor_reading()
 
-    print("Wait for interval specified in Step 1 and get sensor reading")
+    log.info("Wait for interval specified in Step 1 and get sensor reading")
 
     sensor_reading_after_wait = wait(
         func=get_sensor_reading,
@@ -124,7 +126,7 @@ def test_set_sensor_reading_interval(
         timeout=reading_interval,
     )
 
-    print("Validate that reading from Step 4 does not equal reading from Step 6")
+    log.info("Validate that reading from Step 4 does not equal reading from Step 6")
     assert (
         sensor_reading_before_wait != sensor_reading_after_wait
     ), "Reading interval from Step 4  equal reading interval from Step 6"
@@ -147,12 +149,12 @@ def test_update_sensor_firmware(get_sensor_info, update_sensor_firmware):
     max_firmware_version = 15
 
     def update_firmware():
-        print("Get original sensor firmware version")
+        log.info("Get original sensor firmware version")
         original_sensor_firmware_version = get_sensor_info().get("firmware_version")
-        print("Request firmware update")
+        log.info("Request firmware update")
         update_sensor_firmware()
 
-        print("Get current sensor firmware version")
+        log.info("Get current sensor firmware version")
         wait(
             func=get_sensor_info,
             condition=lambda x: isinstance(x, dict),
@@ -161,7 +163,7 @@ def test_update_sensor_firmware(get_sensor_info, update_sensor_firmware):
         )
         current_sensor_firmware_version = get_sensor_info().get("firmware_version")
 
-        print(
+        log.info(
             "Validate that current firmware version is +1 to original firmware version"
         )
         assert (
@@ -172,29 +174,29 @@ def test_update_sensor_firmware(get_sensor_info, update_sensor_firmware):
 
     current_sensor_firmware_version = update_firmware()
 
-    print("Repeat steps 1-4 until sensor is at max_firmware_version - 1")
+    log.info("Repeat steps 1-4 until sensor is at max_firmware_version - 1")
     while current_sensor_firmware_version < max_firmware_version - 1:
         current_sensor_firmware_version = update_firmware()
 
-    print("Update sensor to max firmware version")
+    log.info("Update sensor to max firmware version")
     updated_sensor_firmware_version = update_firmware()
 
-    print("Validate that sensor is at max firmware version")
+    log.info("Validate that sensor is at max firmware version")
     assert (
         updated_sensor_firmware_version == max_firmware_version
     ), "Sensor is not at max firmware version"
 
-    print("Request another firmware update")
+    log.info("Request another firmware update")
     update_response_when_sensor_at_max_version = update_sensor_firmware()
     current_sensor_firmware_version = get_sensor_info().get("firmware_version")
 
-    print("Validate that sensor does not update and responds appropriately")
+    log.info("Validate that sensor does not update and responds appropriately")
     assert (
         update_response_when_sensor_at_max_version
         == "already at latest firmware version"
     ), "Sensor didn't respond properly to a request asking it to update beyond the maximum version"
 
-    print(
+    log.info(
         "Validate that sensor firmware version doesn't change if it's at maximum value"
     )
     assert (


### PR DESCRIPTION
﻿﻿﻿You can now specify log level with --log-cli-level when invoking pytest.
﻿﻿﻿All factory fixtures are scoped to session.
﻿﻿﻿Automatically reset sensor to factory defaults on session start.
﻿﻿﻿Automatically ensure sensor is at factory settings before each test and reset if needed.